### PR TITLE
Max/video homepage

### DIFF
--- a/app/assets/javascripts/nav.js
+++ b/app/assets/javascripts/nav.js
@@ -1,13 +1,9 @@
 /* Set the width of the side navigation to 250px */
 function moveNav() {
   var navBar = document.getElementById("mySideNav");
-  if (navBar.style.width != "250px") {
-    navBar.style.width = "250px";
+  if (navBar.style.right == "0px") {
+      navBar.style.right = "-300px";
   } else {
-    navBar.style.width = "0px";
+      navBar.style.right = "0px";
   }
-}
-
-function highLight() {
-  var highlight = document.getElementById('');
 }

--- a/app/assets/stylesheets/general.scss
+++ b/app/assets/stylesheets/general.scss
@@ -1,4 +1,3 @@
-
 /* Colors
 ------------ */
 $ash: #383838;
@@ -205,11 +204,11 @@ nav {
 
 .sidenav {
   height: 100%;
-  width: 0;
+  width: 300px;
   position: fixed;
   z-index: 1;
   top: 49px;
-  right: 0;
+  right: -300px;
   background-color: $ash;
   overflow-x: hidden;
   padding-top: 52px;
@@ -217,7 +216,7 @@ nav {
   border-left:1px solid black;
 
   li {
-    margin: 10px;
+    margin: 20px;
     padding: 8px;
   }
 
@@ -308,14 +307,20 @@ nav {
   }
 }
 
+.involve_buttons{
+  display: flex;
+  flex-flow: row wrap;
+}
+
 .action_button {
   background-color: $ted_red;
-  max-width: 300px;
+  min-width: 200px;
   padding: 16px;
+  margin: 10px;
 }
 
 .banner {
-  min-height: 800px;
+  min-height: 500px;
 
   display: flex;
   align-items: center;
@@ -593,6 +598,40 @@ nav {
   }
 }
 
+.talk_lists {
+  display: flex;
+  flex-flow: column;
+  min-height: 500px;
+  padding: 40px;
+  background-color: $white;
+}
+
+
+.talk_box {
+  height: 200px;
+  width: 200px;
+  margin: 10px;
+  padding: 10px;
+
+  background-color: $ash;
+
+  &:hover {
+    background-color:rgba(172, 0, 0, 1);
+    transition: .4s;
+    -webkit-transition: .4s;
+  }
+}
+
+.talk_category {
+  display: flex;
+  flex-flow: row wrap;
+  background-color: $white;
+}
+
+.category_title {
+  color: $ted_red
+}
+
 /* Specific Index View
 ------------ */
 .nomination {
@@ -790,9 +829,9 @@ nav {
 -------------- */
 
 .wrapper {
-  display: block;
+  display: flex;
   align-items: center;
-  flex-flow: wrap row;
+  flex-flow: row wrap;
 
   margin: 0px 120px;
 
@@ -839,4 +878,25 @@ and (max-width: 750px) {
       font-size: 12px;
     }
   }
+}
+
+
+// Embedded Youtube Styling
+.embed-container {
+  position: relative;
+  padding-bottom: 56.25%;
+  padding-top: 30px;
+  height: 0;
+  overflow: hidden;
+  width: 100%;
+  height: auto;
+}
+
+.embed-container iframe,
+.embed-container object,
+.embed-container embed {
+  position: absolute;
+  top: 0; left: 0;
+  width: 100%;
+  height: 100%;
 }

--- a/app/assets/stylesheets/general.scss
+++ b/app/assets/stylesheets/general.scss
@@ -790,7 +790,7 @@ nav {
 -------------- */
 
 .wrapper {
-  display: flex;
+  display: block;
   align-items: center;
   flex-flow: wrap row;
 
@@ -801,12 +801,25 @@ nav {
   }
 }
 
+// Safari Hack because safari has strange support for flexbox
+@supports (overflow:-webkit-marquee) and (justify-content:inherit) {
+  .wrapper {
+    display: flex;
+    margin: 0px 10%;
+    flex-flow: column;
+  }
+
+  .speaker {
+    min-width: 90%;
+  }
+
+}
+
 @media screen
 and (min-width: 200px)
 and (max-width: 750px) {
   .wrapper {
     margin: 0px 10%;
-    flex-flow: column;
   }
 
   .speaker {

--- a/app/assets/stylesheets/general.scss
+++ b/app/assets/stylesheets/general.scss
@@ -608,7 +608,7 @@ nav {
 
   .speaker_link {
     display: flex;
-    flex-flow: row;
+    flex-flow: row wrap;
     min-width: 80%;
   }
 
@@ -627,7 +627,7 @@ nav {
 
 .team_index {
   display: flex;
-  flex-flow: row;
+  flex-flow: row wrap;
 }
 
 .team_contents {
@@ -792,7 +792,7 @@ nav {
 .wrapper {
   display: flex;
   align-items: center;
-  flex-flow: wrap;
+  flex-flow: wrap row;
 
   margin: 0px 120px;
 
@@ -803,9 +803,14 @@ nav {
 
 @media screen
 and (min-width: 200px)
-and (max-width: 700px) {
+and (max-width: 750px) {
   .wrapper {
     margin: 0px 10%;
+    flex-flow: column;
+  }
+
+  .speaker {
+    min-width: 90%
   }
 
   .speaker_bio {

--- a/app/controllers/speakers_controller.rb
+++ b/app/controllers/speakers_controller.rb
@@ -52,6 +52,7 @@ class SpeakersController < ApplicationController
       :tagline,
       :twitter,
       :website,
+      :youtube_url,
     )
   end
 

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,5 +1,7 @@
 class StaticPagesController < ApplicationController
   def home
+    @popular_talks = Speaker.limit(5).order("RANDOM()") # TODO: Replace with 5 most popular talks
+    @staff_talks = Speaker.limit(5).order("RANDOM()") # TODO: Replace with some staff favorites
   end
 
   def team

--- a/app/helpers/speakers_helper.rb
+++ b/app/helpers/speakers_helper.rb
@@ -1,2 +1,6 @@
 module SpeakersHelper
+  def embed(youtube_url)
+    youtube_id = youtube_url.split("=").last
+    content_tag(:iframe, nil, src: "//www.youtube.com/embed/#{youtube_id}")
+  end
 end

--- a/app/models/speaker.rb
+++ b/app/models/speaker.rb
@@ -10,6 +10,7 @@
 #  name        :string           not null
 #  tagline     :string           not null
 #  twitter     :string
+#  youtube_url :string
 #  website     :string
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null

--- a/app/views/shared/_footer.html.haml
+++ b/app/views/shared/_footer.html.haml
@@ -1,9 +1,9 @@
 .footer
   %h3.content.left TEDxBerkeley
   %ul.content
-    %li.content= link_to 'Facebook', 'https://www.facebook.com/TEDxBerkeley', class: 'content'
-    %li.content= link_to 'Google +', 'https://plus.google.com/+TedxberkeleyOrg', class: 'content'
-    %li.content= link_to 'LinkedIn', 'https://www.linkedin.com/company/tedx-berkeley', class: 'content'
-    %li.content= link_to 'Instagram', 'https://www.instagram.com/tedxberkeley', class: 'content'
-    %li.content= link_to 'Twitter', 'https://twitter.com/tedxberkeley', class: 'content'
-    %li.content= link_to 'YouTube', 'https://www.youtube.com/channel/UCsT0YIqwnpJCM-mx7-gSA4Q', class: 'content'
+    %li.content= link_to 'Facebook', 'https://www.facebook.com/TEDxBerkeley', class: 'content', target: 'blank'
+    %li.content= link_to 'Google +', 'https://plus.google.com/+TedxberkeleyOrg', class: 'content', target: 'blank'
+    %li.content= link_to 'LinkedIn', 'https://www.linkedin.com/company/tedx-berkeley', class: 'content', target: 'blank'
+    %li.content= link_to 'Instagram', 'https://www.instagram.com/tedxberkeley', class: 'content', target: 'blank'
+    %li.content= link_to 'Twitter', 'https://twitter.com/tedxberkeley', class: 'content', target: 'blank'
+    %li.content= link_to 'YouTube', 'https://www.youtube.com/channel/UCsT0YIqwnpJCM-mx7-gSA4Q', class: 'content', target: 'blank'

--- a/app/views/shared/_nav.html.haml
+++ b/app/views/shared/_nav.html.haml
@@ -1,7 +1,7 @@
 %nav
   = link_to root_url, id: "logo" do
     %h1.title TEDxBerkeley
-  = link_to "http://www.eventbrite.com", class: "tickets_button" do
+  = link_to "http://www.eventbrite.com", class: "tickets_button", target: "blank" do
     %h4 Purchase Tickets
   %i{class: "fa fa-bars draw_button", onclick: "moveNav()"}
   %div{class: "sidenav", id: "mySideNav"}

--- a/app/views/speakers/edit.html.haml
+++ b/app/views/speakers/edit.html.haml
@@ -4,11 +4,12 @@
 
   = form_for :speaker, url: speakers_path, html: {class: "new-form directUpload"}, data: { 'form-data' => (@s3_direct_post.fields), 'url' => @s3_direct_post.url, 'host' => URI.parse(@s3_direct_post.url).host } do |f|
     = f.text_field :name
-    = f.collection_select :event_id, Event.order(:year),:id,:year, include_blank: false
+    = f.collection_select :event_id, Event.order(:date),:id,:theme, include_blank: false
     = f.text_field :tagline
     = f.text_field :quote
+    = f.text_field :website
+    = f.text_field :twitter
+    = f.text_field :youtube_url
     = f.text_area :description
     = f.file_field :photo_url
     = f.submit "Update"
-
-

--- a/app/views/speakers/new.html.haml
+++ b/app/views/speakers/new.html.haml
@@ -8,6 +8,9 @@
     = f.collection_select :event_id, Event.order(:date),:id,:date, include_blank: false
     = f.text_field :tagline, placeholder:"Tagline"
     = f.text_field :quote, placeholder:"Quote"
+    = f.text_field :website, placeholder:"Website"
+    = f.text_field :twitter, placeholder:"Twitter Handle"
+    = f.text_field :youtube_url, placeholder: "Youtube URL"
     = f.text_area :description, placeholder:"Description"
     = f.file_field :photo_url
     = f.submit "Submit"

--- a/app/views/speakers/show.html.haml
+++ b/app/views/speakers/show.html.haml
@@ -1,3 +1,6 @@
+- if @speaker.youtube_url
+  .embed-container
+    = embed(@speaker.youtube_url)
 .focus_panel
   .wrapper
     %img.photo{src: @speaker.photo_url}
@@ -15,4 +18,3 @@
 .show_action_buttons
   %h2.tickets_button Purchase Tickets
   %h2.event_button More Information
-

--- a/app/views/static_pages/home.html.haml
+++ b/app/views/static_pages/home.html.haml
@@ -1,11 +1,26 @@
 .banner#first_banner
-  =link_to "http://www.eventbrite.com/e/tedxberkeley-2016-finding-x-tickets-18508165421" do
+  =link_to @current_event do
     .action_button
-      %h2.ticket_button Buy Tickets Now!
-.banner#second_banner
-  %h3.about_button Learn More
-.banner#third_banner
-  .float_frame
-    %h3.init_box Cats Initiative
-    %h3.init_box Dogs initiative
-    %h3.init_box ChinChilla Initiative
+      %h2.ticket_button TEDxBerkeley #{@current_event.date.year}
+.talk_lists
+  %h2.category_title 2016 Talks
+  .talk_category
+    -@current_event.speakers.limit(5).each do |speaker|
+      =link_to speaker, class: 'speaker_link' do
+        .talk_box
+          %h3= speaker.name
+          %h4= speaker.tagline
+  %h2.category_title Most Popular Talks
+  .talk_category
+    -@popular_talks.each do |speaker|
+      =link_to speaker, class: 'speaker_link' do
+        .talk_box
+          %h3= speaker.name
+          %h4= speaker.tagline
+  %h2.category_title Staff Favorites
+  .talk_category
+    -@staff_talks.each do |speaker|
+      =link_to speaker, class: 'speaker_link' do
+        .talk_box
+          %h3= speaker.name
+          %h4= speaker.tagline

--- a/app/views/static_pages/involve.html.haml
+++ b/app/views/static_pages/involve.html.haml
@@ -3,11 +3,15 @@
     %h1 Get Involved!
     %p TED is an annual event where the world’s leading thinkers and doers are invited to share their passions. “TED” stands for Technology, Entertainment, Design–three broad subject areas that are shaping our future. Attendees have called it “the ultimate brain spa.” The diverse audience– CEOs, scientists, creatives, philanthropists–is almost as extraordinary as the speakers, who have included Bill Clinton, Bill Gates, Jane Goodall, Frank Gehry, Steve Jobs, Sir Richard Branson and Bono.
 
-    =link_to new_nomination_path do
-      %h1 Suggest a Speaker
+    .involve_buttons
+      =link_to new_nomination_path do
+        .action_button
+          %h3 Suggest a Speaker
 
-    =link_to 'mailto:info@tedxberkeley.org' do
-      %h1 Become a Volunteer
+      =link_to 'mailto:info@tedxberkeley.org' do
+        .action_button
+          %h3 Become a Volunteer
 
-    =link_to 'mailto:info@tedxberkeley.org' do
-      %h1 Become a Partner
+      =link_to 'mailto:info@tedxberkeley.org' do
+        .action_button
+          %h3 Become a Partner

--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -1,0 +1,6 @@
+Aws.config.update({
+  region: 'us-east-1',
+  credentials: Aws::Credentials.new(ENV['AWS_ACCESS_KEY_ID'], ENV['AWS_SECRET_ACCESS_KEY']),
+})
+
+S3_BUCKET = Aws::S3::Resource.new.bucket(ENV['S3_BUCKET'])

--- a/db/migrate/20150726223846_create_speakers.rb
+++ b/db/migrate/20150726223846_create_speakers.rb
@@ -9,6 +9,7 @@ class CreateSpeakers < ActiveRecord::Migration
       t.string :name, null: false
       t.string :tagline, null: false
       t.string :twitter
+      t.string :youtube_url
       t.string :website
 
       t.timestamps null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -42,6 +42,7 @@ ActiveRecord::Schema.define(version: 20160725203430) do
     t.string   "name",        null: false
     t.string   "tagline",     null: false
     t.string   "twitter"
+    t.string   "youtube_url"
     t.string   "website"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false

--- a/spec/models/speaker_spec.rb
+++ b/spec/models/speaker_spec.rb
@@ -10,6 +10,7 @@
 #  name        :string           not null
 #  tagline     :string           not null
 #  twitter     :string
+#  youtube_url :string
 #  website     :string
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null

--- a/test/fixtures/speakers.yml
+++ b/test/fixtures/speakers.yml
@@ -10,6 +10,7 @@
 #  name        :string           not null
 #  tagline     :string           not null
 #  twitter     :string
+#  youtube_url :string
 #  website     :string
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null

--- a/test/models/speaker_test.rb
+++ b/test/models/speaker_test.rb
@@ -10,6 +10,7 @@
 #  name        :string           not null
 #  tagline     :string           not null
 #  twitter     :string
+#  youtube_url :string
 #  website     :string
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null


### PR DESCRIPTION
Fix #35 

Adds a speaker information to the landing page, so it's less - blob like. 
Adds video embedding to speaker show view, so that a video pops up if there's one to show for a speaker. 
Fix the expanding nav bar to have a fixed width. 
Links open in a separate tab.

Also fixes some styling problems on safari. 
